### PR TITLE
Improved sprite batch efficiency

### DIFF
--- a/src/Graphics/SpriteBatch.cs
+++ b/src/Graphics/SpriteBatch.cs
@@ -1083,6 +1083,12 @@ namespace Microsoft.Xna.Framework.Graphics
 					 * increase the graphics buffer sizes!
 					 * -flibit
 					 */
+
+					 /* Fix: reallocation size now increase exponentially, 
+					  * but upper bounded to 1048576. When we submit more than 
+					  * 1048576 sprites, we flush them immediately. This will make
+					  * the total running time O(n).
+					 */ 
 					int newMax = Math.Min(vertexInfo.Length * 2, MAX_BATCHSIZE);
 					Array.Resize(ref vertexInfo, newMax);
 					Array.Resize(ref textureInfo, newMax);

--- a/src/Graphics/SpriteBatch.cs
+++ b/src/Graphics/SpriteBatch.cs
@@ -1267,7 +1267,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 			int arrayOffset = 0;
 		nextbatch:
-			int batchSize = numSprites;
+			int batchSize = Math.Min(numSprites, MAX_SPRITES);
 			int baseOff = UpdateVertexBuffer(arrayOffset, batchSize);
 			int offset = 0;
 
@@ -1284,10 +1284,10 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 			DrawPrimitives(curTexture, baseOff + offset, batchSize - offset);
 
-			if (numSprites > batchSize)
+			if (numSprites > MAX_SPRITES)
 			{
-				numSprites -= batchSize;
-				arrayOffset += batchSize;
+				numSprites -= MAX_SPRITES;
+				arrayOffset += MAX_SPRITES;
 				goto nextbatch;
 			}
 			numSprites = 0;


### PR DESCRIPTION
The original method used by FNA takes the time complexity of O(n^2/2048), the new approach I used only takes O(n). I spotted a significant improvement when the player first enters a world with the map fully revealed. Which involves drawing millions of small blocks to the Map render target. It used to take 4-16 seconds but now takes less than 100ms.