### PR TITLE
Made `EffectParameterCollection` to throw if parameter with specified name does not exist

### DIFF
--- a/src/Graphics/Effect/EffectParameterCollection.cs
+++ b/src/Graphics/Effect/EffectParameterCollection.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Xna.Framework.Graphics
 						return elem;
 					}
 				}
-				throw new IndexOutOfRangeException($"Parameter with name '{name}' does not exist in effect.");
+				throw new KeyNotFoundException($"Parameter with name '{name}' does not exist in effect.");
 			}
 		}
 

--- a/src/Graphics/Effect/EffectParameterCollection.cs
+++ b/src/Graphics/Effect/EffectParameterCollection.cs
@@ -8,6 +8,7 @@
 #endregion
 
 #region Using Statements
+using System;
 using System.Collections;
 using System.Collections.Generic;
 #endregion
@@ -45,7 +46,7 @@ namespace Microsoft.Xna.Framework.Graphics
 						return elem;
 					}
 				}
-				return null; // FIXME: ArrayIndexOutOfBounds? -flibit
+				throw new IndexOutOfRangeException($"Parameter with name '{name}' does not exist in effect.");
 			}
 		}
 


### PR DESCRIPTION
### Why should this be part of tModLoader?
More helpful/verbose comparing to `NullReferenceException`.

### Are there alternative designs?
Add null checks.

### Sample usage
If shader is missing a paremeter then it will properly throw instead of `NullReferenceException`